### PR TITLE
CYTODL_CONFIG_PATH should be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with
 **A:** You may need to configure the `CUDA_VISIBLE_DEVICES` [environment variable](https://developer.nvidia.com/blog/cuda-pro-tip-control-gpu-visibility-cuda_visible_devices/).
 
 ## Set env variables
-
+To run the models, you must set the `CYTODL_CONFIG_PATH` environment variable to point to the `br/configs` folder.
+Check that your current working directory is the `benchmarking_representations` folder, then run the following command (this will last for only the duration of your shell session).
 ```bash
-export CYTODL_CONFIG_PATH=./br/configs/
+export CYTODL_CONFIG_PATH=$PWD/br/configs/
 ```
 
 ## Steps to download and preprocess data


### PR DESCRIPTION
# Issue
With `export CYTODL_CONFIG_PATH=./br/configs/`, the path will only be correct if subsequent commands are run from the `benchmarking_representations` folder (because the `.` is not automatically expanded to the full path to the current working directory).

Closes #12 

# Changes
Set an absolute path so that `CYTODL_CONFIG_PATH` can be used from any folder.

# Testing
Only the following:
```
$ export CYTODL_CONFIG_PATH=./br/configs/
$ echo $CYTODL_CONFIG_PATH               
./br/configs/
$ export CYTODL_CONFIG_PATH=$PWD/br/configs/
$ echo $CYTODL_CONFIG_PATH                  
/home/philip.garrison/workspace/aics/benchmarking_representations/br/configs/
```