### PR TITLE
Fixed file_path in cellpack.py

### DIFF
--- a/src/pointcloudutils/datamodules/cellpack.py
+++ b/src/pointcloudutils/datamodules/cellpack.py
@@ -499,9 +499,17 @@ def get_packing(tup):
 
         # for image models
         if get_image:
-            this_path = this_path + "figures/"
-            this_path = this_path.replace("positions", "voxelized_image").split(".")[0]
+            # Replace "positions" with "/figures/voxelized_image"
+            if "positions" in this_path:
+                this_path = this_path.replace("positions", "figures/voxelized_image")
+
+            # Remove the original file extension (.json in this case)
+            this_path = this_path.rsplit(".", 1)[0]  # This splits on the last dot and keeps the first part
+
+            # Append the new file extension
             this_path = this_path + "_seed_0.ome.tiff"
+
+            # Now you can load the image as before
             tmp = imread(this_path)
             points = tmp[:, 1, :, :]
             points = np.pad(points, ((0, 0), (0, 0), (117, 117)))


### PR DESCRIPTION
# Issue
There was a slight mismatch in referencing the file paths for the embeddings (the paths for the positions and voxelized images were in different folders)

# Changes
Corrected the referencing to the voxelized images

# Testing
You can try to run all the cells up to the compute_embedding cell (cell #4) in this notebook (https://github.com/AllenCell/benchmarking_representations/blob/main/src/br/notebooks/fig2_cellpack.ipynb) 
