### PR TITLE
Removed FOV info from scripts for image preprocessing

### DIFF
--- a/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/align_and_mask.py
+++ b/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/align_and_mask.py
@@ -157,7 +157,6 @@ class AlignMaskNormalize(Step):
 
         return {
             self.cell_id_col: cell_id,
-            self.fov_id_col: row[self.fov_id_col],
             self.structure_name_col: row[self.structure_name_col],
             "aligned_image": str(output_path),
             "angle": angle,

--- a/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/merge.py
+++ b/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/merge.py
@@ -129,32 +129,16 @@ class Merge(Step):
             ]
         ]
 
-        # Read in fov image and create brightfield cell channel
-        # as well as DNA if available
-        fov_img = _FOV_IMG if _FOV_IMG is not None else read_image(path_fov)
-
-        # get channel indices
-        bf_channel, dna_channel = self.parse_channelnames(fov_img.channel_names)
-        if dna_channel is not None:
-            raw_dna = raw_img.get_image_data(
-                "ZYX", S=0, T=0, C=channel_map[self.raw_col].index("dna")
-            )
-            check_dna_channel(fov_img, raw_dna, dna_channel, roi)
-
-        # do conversion step to get bright-field channel
-        cropped_bf = get_resized_fov_channel(fov_img, bf_channel, roi)
-
         # stack channels
         data_new = np.vstack(
             (
-                np.expand_dims(cropped_bf, axis=0),
                 raw_img.get_image_data("CZYX", S=0, T=0),
                 seg_img.get_image_data("CZYX", S=0, T=0, C=seg_channels_to_use),
             )
         ).astype("uint16")
 
         channel_names = (
-            ["bf"] + raw_channel_names + [seg_channel_names[ix] for ix in seg_channels_to_use]
+            raw_channel_names + [seg_channel_names[ix] for ix in seg_channels_to_use]
         )
 
         output_path = self.store_image(
@@ -163,7 +147,6 @@ class Merge(Step):
 
         return {
             self.cell_id_col: cell_id,
-            self.fov_id_col: row[self.fov_id_col],
             self.structure_name_col: row[self.structure_name_col],
             "merged_channels": str(output_path),
             "success": True,

--- a/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/register.py
+++ b/src/br/data/preprocessing/image_preprocessing/image_preprocessing/steps/register.py
@@ -72,34 +72,8 @@ class Register(Step):
             image_name="default",
         )
 
-        # self.output_format = "ome.tiff"
-        # base_output_dir = Path(self.output_dir).parent
-        # for ix, axis in enumerate(["z", "y", "x"]):
-        #     for projection_type in ["max", "mean", "median"]:
-        #         op = getattr(np, projection_type)
-        #         projection = op(img_data, axis=ix + 1)  # c = 0, z = 1, y = 2, x = 3
-
-        #         prefix = f"{projection_type}_projection_{axis}"
-        #         self.output_dir = base_output_dir / prefix
-        #         paths[f"{projection_type}_projection_{axis}"] = self.store_image(
-        #             projection,
-        #             img.channel_names,
-        #             None,
-        #             cell_id,
-        #         )
-
-        # self.output_dir = base_output_dir / "center_slice"
-        # center_slice = img_data[:, img_data.shape[1] // 2, :, :]
-        # paths["center_slice"] = self.store_image(
-        #     center_slice,
-        #     img.channel_names,
-        #     None,
-        #     cell_id,
-        # )
-
         return {
             self.cell_id_col: cell_id,
-            self.fov_id_col: row[self.fov_id_col],
             self.structure_name_col: row[self.structure_name_col],
             "success": True,
             **paths,


### PR DESCRIPTION
Since we are dealing with single-cell images, the fov level image info will not be needed. Removed these from some preprocessing scripts. For now, since there are too many conflicting env dependencies, I am not including test scripts!