### PR TITLE
add csv logger to all experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ In all cases, create a single cell manifest (e.g. csv, parquet) for each dataset
 Here is an example of training a rotation invariant point cloud model
 
 ```bash
-python src/br/models/train.py experiment=cellpack/pc_equiv ++mlflow.experiment_name=[EXPERIMENT_NAME] ++mlflow.run_name=[RUN_NAME]
+python src/br/models/train.py experiment=cellpack/pc_so3
 ```
 
 Override parts of the experiment config via command line or manually in the configs. For example, to train a classical model, run
 
 ```bash
-python src/br/models/train.py experiment=cellpack/pc_equiv model=pc/classical_earthmovers_sphere ++mlflow.experiment_name=[EXPERIMENT_NAME] ++mlflow.run_name=[RUN_NAME]
+python src/br/models/train.py experiment=cellpack/pc_so3 model=pc/classical_earthmovers_sphere ++csv.save_dir=[SAVE_DIR]
 ```
 
 ## Steps to download pre-trained models and pre-computed embeddings

--- a/configs/experiment/cellpack/image_classical.yaml
+++ b/configs/experiment/cellpack/image_classical.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./cellpack/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./cellpack
     name: "classical_image"
     prefix:
 

--- a/configs/experiment/cellpack/image_classical.yaml
+++ b/configs/experiment/cellpack/image_classical.yaml
@@ -4,16 +4,17 @@
 # python train.py experiment=example
 
 defaults:
-  - override /data: pcna/pc_intensity.yaml
-  - override /model: pc/so3_earthmovers_intensity.yaml
+  - override /data: cellpack/image.yaml
+  - override /model: image/classical.yaml
   - override /callbacks: default.yaml
   - override /trainer: default.yaml
   - override /logger: csv.yaml
+  # - override /hydra: private/joblib
 
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
-experiment_name: pcna
+experiment_name: cellpack
 tags: ["equivariance"]
 
 seed: 42
@@ -22,12 +23,12 @@ model:
   x_label: pcloud
 
 data:
-  batch_size: 32
+  batch_size: 2
 
 trainer:
   check_val_every_n_epoch: 1
   min_epochs: 400
-  max_epochs: 2000
+  max_epochs: 800
   accelerator: gpu
   devices: [0]
 
@@ -44,7 +45,7 @@ callbacks:
 logger:
   csv:
     save_dir: ./outputs
-    name: "so3_pointcloud"
+    name: "classical_image"
     prefix:
 
 ##### ONLY USE WITH A100s

--- a/configs/experiment/cellpack/image_so3.yaml
+++ b/configs/experiment/cellpack/image_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name:
-    run_name:
+  csv:
+    save_dir: ./outputs
+    name: "so3_image"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/cellpack/image_so3.yaml
+++ b/configs/experiment/cellpack/image_so3.yaml
@@ -37,7 +37,7 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./cellpack/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1

--- a/configs/experiment/cellpack/image_so3.yaml
+++ b/configs/experiment/cellpack/image_so3.yaml
@@ -44,7 +44,7 @@ callbacks:
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./cellpack
     name: "so3_image"
     prefix:
 

--- a/configs/experiment/cellpack/pc_classical.yaml
+++ b/configs/experiment/cellpack/pc_classical.yaml
@@ -4,16 +4,17 @@
 # python train.py experiment=example
 
 defaults:
-  - override /data: pcna/pc_intensity.yaml
-  - override /model: pc/so3_earthmovers_intensity.yaml
+  - override /data: cellpack/pc_jitter.yaml
+  - override /model: pc/classical_earthmovers_sphere.yaml
   - override /callbacks: default.yaml
   - override /trainer: default.yaml
   - override /logger: csv.yaml
+  # - override /hydra: private/joblib
 
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
-experiment_name: pcna
+experiment_name: cellpack
 tags: ["equivariance"]
 
 seed: 42
@@ -27,7 +28,7 @@ data:
 trainer:
   check_val_every_n_epoch: 1
   min_epochs: 400
-  max_epochs: 2000
+  max_epochs: 800
   accelerator: gpu
   devices: [0]
 
@@ -44,7 +45,7 @@ callbacks:
 logger:
   csv:
     save_dir: ./outputs
-    name: "so3_pointcloud"
+    name: "classical_pointcloud"
     prefix:
 
 ##### ONLY USE WITH A100s

--- a/configs/experiment/cellpack/pc_classical.yaml
+++ b/configs/experiment/cellpack/pc_classical.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./cellpack/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./cellpack
     name: "classical_pointcloud"
     prefix:
 

--- a/configs/experiment/cellpack/pc_so3.yaml
+++ b/configs/experiment/cellpack/pc_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./cellpack/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./cellpack
     name: "so3_pointcloud"
     prefix:
 

--- a/configs/experiment/cellpack/pc_so3.yaml
+++ b/configs/experiment/cellpack/pc_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_pointcloud"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/image_sdf_classical.yaml
+++ b/configs/experiment/npm1_perturb/image_sdf_classical.yaml
@@ -36,15 +36,15 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_perturb/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
-    name: "classical_sdf"
+    save_dir: ./npm1_perturb
+    name: so3_sdf
     prefix:
 
 ##### ONLY USE WITH A100s

--- a/configs/experiment/npm1_perturb/image_sdf_classical.yaml
+++ b/configs/experiment/npm1_perturb/image_sdf_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/image_sdf_so3.yaml
+++ b/configs/experiment/npm1_perturb/image_sdf_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_perturb/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_perturb
     name: "so3_sdf"
     prefix:
 

--- a/configs/experiment/npm1_perturb/image_sdf_so3.yaml
+++ b/configs/experiment/npm1_perturb/image_sdf_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/image_seg_classical.yaml
+++ b/configs/experiment/npm1_perturb/image_seg_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/image_seg_classical.yaml
+++ b/configs/experiment/npm1_perturb/image_seg_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_perturb/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_perturb
     name: "classical_seg"
     prefix:
 

--- a/configs/experiment/npm1_perturb/image_seg_so3.yaml
+++ b/configs/experiment/npm1_perturb/image_seg_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/image_seg_so3.yaml
+++ b/configs/experiment/npm1_perturb/image_seg_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_perturb/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_perturb
     name: "so3_seg"
     prefix:
 

--- a/configs/experiment/npm1_perturb/pc_implicit.yaml
+++ b/configs/experiment/npm1_perturb/pc_implicit.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "pc_implicit"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_perturb/pc_implicit.yaml
+++ b/configs/experiment/npm1_perturb/pc_implicit.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_perturb/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_perturb
     name: "pc_implicit"
     prefix:
 

--- a/configs/experiment/npm1_variance/image_sdf_classical.yaml
+++ b/configs/experiment/npm1_variance/image_sdf_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_variance/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_variance
     name: "classical_sdf"
     prefix:
 

--- a/configs/experiment/npm1_variance/image_sdf_classical.yaml
+++ b/configs/experiment/npm1_variance/image_sdf_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_variance/image_sdf_so3.yaml
+++ b/configs/experiment/npm1_variance/image_sdf_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_variance/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_variance
     name: "so3_sdf"
     prefix:
 

--- a/configs/experiment/npm1_variance/image_sdf_so3.yaml
+++ b/configs/experiment/npm1_variance/image_sdf_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_variance/image_seg_classical.yaml
+++ b/configs/experiment/npm1_variance/image_seg_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_variance/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_variance
     name: "classical_seg"
     prefix:
 

--- a/configs/experiment/npm1_variance/image_seg_classical.yaml
+++ b/configs/experiment/npm1_variance/image_seg_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_variance/image_seg_so3.yaml
+++ b/configs/experiment/npm1_variance/image_seg_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_variance/image_seg_so3.yaml
+++ b/configs/experiment/npm1_variance/image_seg_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_variance/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_variance
     name: "so3_seg"
     prefix:
 

--- a/configs/experiment/npm1_variance/pc_implicit.yaml
+++ b/configs/experiment/npm1_variance/pc_implicit.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "pc_implicit"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/npm1_variance/pc_implicit.yaml
+++ b/configs/experiment/npm1_variance/pc_implicit.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./npm1_variance/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./npm1_variance
     name: "pc_implicit"
     prefix:
 

--- a/configs/experiment/other_polymorphic/image_sdf_classical.yaml
+++ b/configs/experiment/other_polymorphic/image_sdf_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_polymorphic/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_polymorphic
     name: "classical_sdf"
     prefix:
 

--- a/configs/experiment/other_polymorphic/image_sdf_classical.yaml
+++ b/configs/experiment/other_polymorphic/image_sdf_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_polymorphic/image_sdf_so3.yaml
+++ b/configs/experiment/other_polymorphic/image_sdf_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_polymorphic/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_polymorphic
     name: "so3_sdf"
     prefix:
 

--- a/configs/experiment/other_polymorphic/image_sdf_so3.yaml
+++ b/configs/experiment/other_polymorphic/image_sdf_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_sdf"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_polymorphic/image_seg_classical.yaml
+++ b/configs/experiment/other_polymorphic/image_seg_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_polymorphic/image_seg_classical.yaml
+++ b/configs/experiment/other_polymorphic/image_seg_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_polymorphic/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_polymorphic
     name: "classical_seg"
     prefix:
 

--- a/configs/experiment/other_polymorphic/image_seg_so3.yaml
+++ b/configs/experiment/other_polymorphic/image_seg_so3.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_seg"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_polymorphic/image_seg_so3.yaml
+++ b/configs/experiment/other_polymorphic/image_seg_so3.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_polymorphic/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_polymorphic
     name: "so3_seg"
     prefix:
 

--- a/configs/experiment/other_polymorphic/pc_implicit.yaml
+++ b/configs/experiment/other_polymorphic/pc_implicit.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_polymorphic/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_polymorphic
     name: "pc_implicit"
     prefix:
 

--- a/configs/experiment/other_polymorphic/pc_implicit.yaml
+++ b/configs/experiment/other_polymorphic/pc_implicit.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "pc_implicit"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_punctate/image_so3.yaml
+++ b/configs/experiment/other_punctate/image_so3.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_punctate/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_punctate
     name: "so3_image"
     prefix:
 

--- a/configs/experiment/other_punctate/image_so3.yaml
+++ b/configs/experiment/other_punctate/image_so3.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_image"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_punctate/image_so3_classical.yaml
+++ b/configs/experiment/other_punctate/image_so3_classical.yaml
@@ -4,8 +4,8 @@
 # python train.py experiment=example
 
 defaults:
-  - override /data: pcna/pc_intensity.yaml
-  - override /model: pc/so3_earthmovers_intensity.yaml
+  - override /data: other_punctate/image.yaml
+  - override /model: image/classical.yaml
   - override /callbacks: default.yaml
   - override /trainer: default.yaml
   - override /logger: csv.yaml
@@ -13,16 +13,16 @@ defaults:
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
 
-experiment_name: pcna
+experiment_name: other_punctate
 tags: ["equivariance"]
 
 seed: 42
 
-model:
-  x_label: pcloud
-
 data:
-  batch_size: 32
+  batch_size: 4
+
+model:
+  x_label: image
 
 trainer:
   check_val_every_n_epoch: 1
@@ -44,7 +44,7 @@ callbacks:
 logger:
   csv:
     save_dir: ./outputs
-    name: "so3_pointcloud"
+    name: "classical_image"
     prefix:
 
 ##### ONLY USE WITH A100s

--- a/configs/experiment/other_punctate/image_so3_classical.yaml
+++ b/configs/experiment/other_punctate/image_so3_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_punctate/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_punctate
     name: "classical_image"
     prefix:
 

--- a/configs/experiment/other_punctate/pc_classical.yaml
+++ b/configs/experiment/other_punctate/pc_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_pointcloud"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/other_punctate/pc_classical.yaml
+++ b/configs/experiment/other_punctate/pc_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_punctate/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_punctate
     name: "classical_pointcloud"
     prefix:
 

--- a/configs/experiment/other_punctate/pc_so3.yaml
+++ b/configs/experiment/other_punctate/pc_so3.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./other_punctate/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./other_punctate
     name: "so3_pointcloud"
     prefix:
 

--- a/configs/experiment/other_punctate/pc_so3.yaml
+++ b/configs/experiment/other_punctate/pc_so3.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_pointcloud"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/pcna/image_classical.yaml
+++ b/configs/experiment/pcna/image_classical.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./pcna/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./pcna
     name: "classical_image"
     prefix:
 

--- a/configs/experiment/pcna/image_classical.yaml
+++ b/configs/experiment/pcna/image_classical.yaml
@@ -4,11 +4,12 @@
 # python train.py experiment=example
 
 defaults:
-  - override /data: pcna/pc_intensity.yaml
-  - override /model: pc/so3_earthmovers_intensity.yaml
+  - override /data: pcna/image.yaml
+  - override /model: image/classical.yaml
   - override /callbacks: default.yaml
   - override /trainer: default.yaml
   - override /logger: csv.yaml
+  # - override /hydra: private/joblib
 
 # all parameters below will be merged with parameters from default configurations set above
 # this allows you to overwrite only specified parameters
@@ -19,15 +20,15 @@ tags: ["equivariance"]
 seed: 42
 
 model:
-  x_label: pcloud
+  x_label: image
 
 data:
-  batch_size: 32
+  batch_size: 2
 
 trainer:
   check_val_every_n_epoch: 1
   min_epochs: 400
-  max_epochs: 2000
+  max_epochs: 800
   accelerator: gpu
   devices: [0]
 
@@ -44,7 +45,7 @@ callbacks:
 logger:
   csv:
     save_dir: ./outputs
-    name: "so3_pointcloud"
+    name: "classical_image"
     prefix:
 
 ##### ONLY USE WITH A100s

--- a/configs/experiment/pcna/image_equiv.yaml
+++ b/configs/experiment/pcna/image_equiv.yaml
@@ -37,15 +37,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "so3_image"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/pcna/image_equiv.yaml
+++ b/configs/experiment/pcna/image_equiv.yaml
@@ -37,14 +37,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./pcna/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./pcna
     name: "so3_image"
     prefix:
 

--- a/configs/experiment/pcna/pc_classical.yaml
+++ b/configs/experiment/pcna/pc_classical.yaml
@@ -36,15 +36,16 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ${paths.output_dir}/ckpts
+    dirpath: ./ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
-  mlflow:
-    experiment_name: test_br
-    run_name: test
+  csv:
+    save_dir: ./outputs
+    name: "classical_pointcloud"
+    prefix:
 
 ##### ONLY USE WITH A100s
 extras:

--- a/configs/experiment/pcna/pc_classical.yaml
+++ b/configs/experiment/pcna/pc_classical.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./pcna/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./pcna
     name: "classical_pointcloud"
     prefix:
 

--- a/configs/experiment/pcna/pc_equiv.yaml
+++ b/configs/experiment/pcna/pc_equiv.yaml
@@ -36,14 +36,14 @@ callbacks:
     monitor: val/loss
 
   model_checkpoint:
-    dirpath: ./ckpts
+    dirpath: ./pcna/ckpts
     monitor: val/loss
     save_top_k: 2
     every_n_epochs: 1
 
 logger:
   csv:
-    save_dir: ./outputs
+    save_dir: ./pcna
     name: "so3_pointcloud"
     prefix:
 


### PR DESCRIPTION
Changes - 

1. Replace mlflow with csv logger everywhere as a default. Save checkpoints and outputs to local paths. 
2. Specify unique name for each experiment. "name" flag associated with CSVLogger
3. Add missing experiments for some datasets (e.g. Classical image experiment for cell pack data)