### PR TITLE
Preprocessing config: Dummy values for fields the user must edit.

### DIFF
--- a/subpackages/image_preprocessing/config/config.yaml
+++ b/subpackages/image_preprocessing/config/config.yaml
@@ -8,11 +8,10 @@ n_workers: 10
 verbose: true
 force: false
 raise_errors: true
-samples_per_structure:
 
-output_dir:
+output_dir: your_output_path_here
 
-input_manifest:
+input_manifest: your_path_here
 
 remote_provider:
 


### PR DESCRIPTION
# Issue
There's ambiguity in many of our config files, and this one in particular, about what variables the user is supposed to set, and which can be left blank.

Ritvik said the `samples_per_structure` is no longer used.

# Changes
* Remove `samples_per_structure`
* Put dummy values in the two required fields so it's clearer what to edit.

# Testing
* Edited `output_dir` and `input_manifest`, then ran `snakemake -s Snakefile --cores all` and it successfully running and creating some outputs. (I didn't wait for the whole thing to complete).