### PR TITLE
Pin working codecarbon version

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "build-requires", "dev", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:98810061b17f4aafcf5418bcb4eced76c4ceadc79c2d483333a73a3c56c70ff0"
+content_hash = "sha256:6ba56bb2c1510baa278c9f30f38cdd613c095077a02766eb77c6da483864962a"
 
 [[metadata.targets]]
 requires_python = "==3.10.*"
@@ -416,7 +416,7 @@ summary = "Collection of methods for performing morphology appropriate represent
 groups = ["dev"]
 dependencies = [
     "PyMCubes>=0.1.4",
-    "codecarbon>=2.4.2",
+    "codecarbon==2.6.0",
     "copairs @ git+https://github.com/cytomining/copairs.git@880f22a551bd897896d148a0b07baa99d981c6a9",
     "cyto-dl[equiv,pcloud,s3,spharm,torchserve] @ git+https://github.com/AllenCellModeling/cyto-dl.git@a4a061d1808e0f94f906933642920142b581ba38",
     "ipykernel>=6.29.5",
@@ -689,7 +689,7 @@ files = [
 
 [[package]]
 name = "codecarbon"
-version = "2.7.1"
+version = "2.6.0"
 requires_python = ">=3.7"
 summary = ""
 groups = ["default", "dev"]
@@ -708,8 +708,8 @@ dependencies = [
     "typer",
 ]
 files = [
-    {file = "codecarbon-2.7.1-py3-none-any.whl", hash = "sha256:d056e3a422b956f7902bb1b7c910487134d6079cdd42f0f6b99abaa9b7302d09"},
-    {file = "codecarbon-2.7.1.tar.gz", hash = "sha256:b1e15cb6746a1b3760719f3534c458f59f22ee0f644a6d0070011093b1c84ee1"},
+    {file = "codecarbon-2.6.0-py3-none-any.whl", hash = "sha256:4e11467f7f844894512dd4cd623da27598c5e803941b45eed8438b06e9410c55"},
+    {file = "codecarbon-2.6.0.tar.gz", hash = "sha256:05b0d39c60650ffa2e4b3eb72fdcbfe29c7853aa2e4c8ab37abea264a749057b"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = "==3.10.*"
 license = {file = "LICENSE"}
 dependencies = [
     "torch-scatter>=2.1.2",
-    "codecarbon>=2.4.2",
+    "codecarbon==2.6.0",
     "PyMCubes>=0.1.4",
     "copairs @ git+https://github.com/cytomining/copairs.git@880f22a551bd897896d148a0b07baa99d981c6a9",
     "pycytominer==1.2.0",

--- a/requirements2.txt
+++ b/requirements2.txt
@@ -40,7 +40,7 @@ cloudpickle==3.0.0
 cmaes==0.10.0
 cmake==3.28.3; platform_system == "Linux" and platform_machine == "x86_64"
 cmd2==2.4.3
-codecarbon==2.7.1
+codecarbon==2.6.0
 colorama==0.4.6
 colorlog==6.8.2
 comm==0.2.2


### PR DESCRIPTION
### Overview
This pull request focuses on testing the [`run_features.py`](https://github.com/AllenCell/benchmarking_representations/blob/main/src/br/analysis/run_features.py) script. The testing was performed after using the updated [`pyproject.toml`](https://github.com/AllenCell/benchmarking_representations/blob/main/pyproject.toml) file and creating a virtual environment for the repository. I also used **codecarbon 2.6.0** to run the commands.

### Results
The scripts executed successfully without any errors!

### Commands Executed
The following commands were run to test the script with different embedding paths and parameters:

1. **Test with Cellpack Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/cellpack" --sdf False --dataset_name "cellpack" --debug False
   ```

2. **Test with Other Punctate Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/other_punctate" --sdf False --dataset_name "other_punctate" --debug False
   ```

3. **Test with Other Polymorphic Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/other_polymorphic" --sdf True --dataset_name "other_polymorphic" --debug False
   ```

4. **Test with NPM1 Perturb Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/npm1_perturb" --sdf True --dataset_name "npm1_perturb" --debug False
   ```

5. **Test with NPM1 Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/npm1" --sdf True --dataset_name "npm1" --debug False
   ```

6. **Test with PCNA Embeddings**
   ```bash
   python src/br/analysis/run_features.py --save_path "/allen/aics/assay-dev/Fatwir/benchmarking_representations_rough/testing/embeddings/" --embeddings_path "./morphology_appropriate_representation_learning/model_embeddings/pcna" --sdf False --dataset_name "pcna" --debug False
   ```

This PR closes [this](https://github.com/AllenCell/benchmarking_representations/issues/51) issue!