### PR TITLE
add quickstart to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ If you'd like to reproduce this analysis on our data, check out the following do
 
 Coming soon
 
+# Quickstart
+
+Use the cytodl api to run any given experiment. For e.g., train a rotation invariant point cloud autoencoder on the PCNA dataset
+
+```bash
+from cyto_dl.api import CytoDLModel
+from pathlib import Path
+
+model =CytoDLModel() 
+model.root= Path(os.getcwd())
+model.load_default_experiment('pcna/pc_equiv', output_dir = './')
+
+model.print_config()
+
+model.train()
+```
+
 # Contact
 
 Allen Institute for Cell Science (cells@alleninstitute.org)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use the cytodl api to run any given experiment. For e.g., train a rotation invar
 from cyto_dl.api import CytoDLModel
 from pathlib import Path
 
-model =CytoDLModel() 
+model = CytoDLModel()
 model.root= Path(os.getcwd())
 model.load_default_experiment('pcna/pc_equiv', output_dir = './')
 


### PR DESCRIPTION
This PR adds a Quickstart to the readme using the CytoDL api.

FYI I had to update the API here - https://github.com/AllenCellModeling/cyto-dl/commit/e8373d7940eca5241264ba711980ace96f8f383d - to load non im2im experiments